### PR TITLE
JWTUtil not existing

### DIFF
--- a/EcosystemSampleApp/JWTUtil.swift
+++ b/EcosystemSampleApp/JWTUtil.swift
@@ -13,8 +13,11 @@ import JWT
 
 class JWTUtil {
     static func encode(header: [AnyHashable: Any], body: [AnyHashable: Any], subject: String, id: String, privateKey: String) -> String? {
+        // In some instances the below guard can return false if this object isn't stored
+        let dataHolder = JWTAlgorithmRSFamilyDataHolder()
+        
         guard let key = try? JWTCryptoKeyPrivate(pemEncoded: privateKey, parameters: nil),
-            let holder = (JWTAlgorithmRSFamilyDataHolder().signKey(key)?.secretData(privateKey.data(using: .utf8))?.algorithmName(JWTAlgorithmNameRS512) as? JWTAlgorithmRSFamilyDataHolder) else {
+            let holder = (dataHolder.signKey(key)?.secretData(privateKey.data(using: .utf8))?.algorithmName(JWTAlgorithmNameRS512) as? JWTAlgorithmRSFamilyDataHolder) else {
                 return nil
         }
         let claims = JWTClaimsSet()


### PR DESCRIPTION
* Main purpose:
 Fixes a rare case of the JWTUtil not being in memory to sign the key.

* Technical description:
Assigned the JWT data holder class to a var.

* Dilemmas you faced with?
This is a rare case not happening on all devices.

* Tests
n/a

* Documentation (Source/readme.md)
n/a
