### PR TITLE
DP-209 - Add get order confirmation button to sample app for manual testing

### DIFF
--- a/EcosystemSampleApp/Base.lproj/Main.storyboard
+++ b/EcosystemSampleApp/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="3vJ-qj-IoG">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="3vJ-qj-IoG">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -29,14 +29,14 @@
                                         </constraints>
                                     </view>
                                     <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" image="kinMarketplaceIcon" translatesAutoresizingMaskIntoConstraints="NO" id="2uH-gP-tyr">
-                                        <rect key="frame" x="107.5" y="13.5" width="160" height="156"/>
+                                        <rect key="frame" x="107.5" y="7.5" width="160" height="156"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="160" id="LBh-Sw-pBM"/>
                                             <constraint firstAttribute="height" constant="156" id="xEY-SF-Wxv"/>
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1.0.0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VDd-2H-tbS">
-                                        <rect key="frame" x="172.5" y="183" width="30" height="20.5"/>
+                                        <rect key="frame" x="172.5" y="171.5" width="30" height="20.5"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="20.5" id="sME-6W-dhg"/>
                                         </constraints>
@@ -45,7 +45,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SRd-bx-wBE">
-                                        <rect key="frame" x="87.5" y="217" width="200" height="20.5"/>
+                                        <rect key="frame" x="87.5" y="199.5" width="200" height="20.5"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="20.5" id="Exk-pm-K7x"/>
                                             <constraint firstAttribute="width" constant="200" id="s7J-KF-4gc"/>
@@ -55,7 +55,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yO7-Yb-Spq">
-                                        <rect key="frame" x="47.5" y="251" width="280" height="50"/>
+                                        <rect key="frame" x="47.5" y="228" width="280" height="50"/>
                                         <color key="backgroundColor" red="0.019607843140000001" green="0.58823529409999997" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="50" id="dQj-1k-PDC"/>
@@ -74,7 +74,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="838-ZL-O1D">
-                                        <rect key="frame" x="47.5" y="314.5" width="280" height="50"/>
+                                        <rect key="frame" x="47.5" y="285.5" width="280" height="50"/>
                                         <color key="backgroundColor" red="0.019607843140000001" green="0.58823529409999997" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
                                         <state key="normal" title="Launch Marketplace">
                                             <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
@@ -89,7 +89,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aty-Ph-D33">
-                                        <rect key="frame" x="47.5" y="378" width="280" height="50"/>
+                                        <rect key="frame" x="47.5" y="343.5" width="280" height="50"/>
                                         <color key="backgroundColor" red="0.019607843137254902" green="0.58823529411764708" blue="0.97254901960784312" alpha="1" colorSpace="calibratedRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="IDq-dW-XqI"/>
@@ -108,7 +108,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rfX-g8-zPH">
-                                        <rect key="frame" x="47.5" y="441.5" width="280" height="50"/>
+                                        <rect key="frame" x="47.5" y="401" width="280" height="50"/>
                                         <color key="backgroundColor" red="0.019607843140000001" green="0.58823529409999997" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="280" id="2AO-tk-IBT"/>
@@ -127,7 +127,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="unZ-0P-rPL">
-                                        <rect key="frame" x="47.5" y="505" width="280" height="50"/>
+                                        <rect key="frame" x="47.5" y="459" width="280" height="50"/>
                                         <color key="backgroundColor" red="0.019607843140000001" green="0.58823529409999997" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="280" id="rr3-K0-EAJ"/>
@@ -142,11 +142,30 @@
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
                                         <connections>
-                                            <action selector="nativeEarnTapped:" destination="3vJ-qj-IoG" eventType="touchUpInside" id="oeq-mU-lze"/>
+                                            <action selector="nativeEarnTapped:" destination="3vJ-qj-IoG" eventType="touchUpInside" id="bOM-Oh-zNR"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="42f-Tx-1aU">
+                                        <rect key="frame" x="47.5" y="516.5" width="280" height="50"/>
+                                        <color key="backgroundColor" red="0.019607843140000001" green="0.58823529409999997" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="U3b-LD-bFx"/>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="280" id="yca-1V-fQE"/>
+                                        </constraints>
+                                        <state key="normal" title="Get Last Order Confirmation">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </state>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                <integer key="value" value="25"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <action selector="orderConfirmationTapped:" destination="3vJ-qj-IoG" eventType="touchUpInside" id="da0-5b-ZAQ"/>
                                         </connections>
                                     </button>
                                     <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="uM8-2O-gfe">
-                                        <rect key="frame" x="177.5" y="568.5" width="20" height="20"/>
+                                        <rect key="frame" x="177.5" y="574.5" width="20" height="20"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="20" id="FvT-Cf-pDk"/>
                                             <constraint firstAttribute="height" constant="20" id="u2c-C4-Gc6"/>

--- a/EcosystemSampleApp/SampleAppViewController.swift
+++ b/EcosystemSampleApp/SampleAppViewController.swift
@@ -347,9 +347,7 @@ class SampleAppViewController: UIViewController, UITextFieldDelegate {
         guard let offerId = lastOfferId else{
             
             let alert = UIAlertController(title: "No Order has Been Made", message: "No Order was sent in this session yet.", preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: "Oh ok", style: .cancel, handler: { [weak alert] action in
-                alert?.dismiss(animated: true, completion: nil)
-            }))
+            alert.addAction(UIAlertAction(title: "Oh ok", style: .cancel))
             self.present(alert, animated: true, completion: nil)
             
             return
@@ -388,9 +386,7 @@ class SampleAppViewController: UIViewController, UITextFieldDelegate {
                         case .failed: break
                         }
                         
-                        alert.addAction(UIAlertAction(title: "Close", style: .cancel, handler: { [weak alert] action in
-                            alert?.dismiss(animated: true, completion: nil)
-                        }))
+                        alert.addAction(UIAlertAction(title: "Close", style: .cancel))
                         
                         self?.present(alert, animated: true, completion: nil)
                     }


### PR DESCRIPTION
* Main purpose:
Add get order confirmation button to sample app for manual testing.
Verify that this call has no problems (in Android a bug was found)
* Technical description:
For making it as easy a possible, I added a button for getting *last* order confirmation based on orders done in this session (I'm saving the order id on each offer)
* Dilemmas you faced with?
* Tests
* Documentation (Source/readme.md)